### PR TITLE
Allow building with Cabal-3.0 (GHC 8.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,15 @@ matrix:
     - env: CABALVER=2.0 GHCVER=8.2.2
       compiler: ": #GHC 8.2.1"
       addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
-    - env: CABALVER=2.2 GHCVER=8.4.3
-      compiler: ": #GHC 8.4.1"
-      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}
-    - env: CABALVER=2.4 GHCVER=8.6.1
-      compiler: ": #GHC 8.6.1"
-      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.2 GHCVER=8.4.4
+      compiler: ": #GHC 8.4.4"
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.6.5
+      compiler: ": #GHC 8.6.5"
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
+    - env: CABALVER=3.0 GHCVER=8.8.1
+      compiler: ": #GHC 8.8.1"
+      addons: {apt: {packages: [cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC


### PR DESCRIPTION
Various minor tweaks are needed to fix the build the custom `Setup` script with `Cabal-3.0`:

* `configCompilerAux` no longer exists in `Cabal-3.0`. The `Setup` script imports it but never uses it, so this import can simply be deleted.
* The following types/functions have been deprecated:

  * `ProgramConfiguration` in favor of `ProgramDb`
  * `rawSystemProgramConf` in favor of `runDbProgram`
  * `die` in favor of `die'`

  Incredibly, all of these are available back to `Cabal-1.10` with the exception of `die'`, which I define a shim for with CPP.