### PR TITLE
Use the correct filepaths in preprocessor mode

### DIFF
--- a/src/State.lhs
+++ b/src/State.lhs
@@ -19,6 +19,7 @@
 >                                          lang       :: Lang,          -- Haskell or Agda, currently
 >                                          verbose    :: Bool,
 >                                          searchpath :: [FilePath],
+>                                          linefile   :: Maybe FilePath,  -- The filepath to use for LINE pragmas, passed by the -h option by GHC in preprocessor mode
 >                                          file       :: FilePath,      -- also used for `hugs'
 >                                          lineno     :: LineNo,
 >                                          ofile      :: FilePath,
@@ -70,6 +71,7 @@ Initial state.
 >                                          separation = 2,
 >                                          latency    = 2,
 >                                          pstack     = [],
+>                                          linefile   = Nothing,
 >                                          -- ks, 03.01.04: added to prevent warnings during compilation
 >                                          style      = error "uninitialized style",
 >                                          file       = error "uninitialized filename",


### PR DESCRIPTION
In the preprocessor mode GHC passes three filepaths in the following
form

-h fp infile outfile

The -h argument is intended to be used in the LINE pragma, and the input
should be read from the input file and written to the output file.

lhs2tex was reading the contents of fp and using that rather than the
infile argument which was only noticed when using lhs2tex as a
preprocessor with ghcide.