### PR TITLE
Better error message when --pre is called with the unexpected number of arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 /lhs2TeX
 /Lhs2TeX
 /dist
+/dist-newstyle

--- a/lhs2tex.cabal
+++ b/lhs2tex.cabal
@@ -1,4 +1,5 @@
-cabal-version:  >=1.10
+cabal-version:  2.0
+  -- autogen-modules
 name:           lhs2tex
 version:        1.24
 license:        GPL

--- a/src/Main.lhs
+++ b/src/Main.lhs
@@ -74,7 +74,9 @@
 >                                       [Copying]     -> quitSuccess (programInfo ++ "\n\n" ++ copying)
 >                                       [Warranty]    -> quitSuccess (programInfo ++ "\n\n" ++ warranty)
 >                                       [Pre] | length n >= 3 -> preprocess flags (reverse initdirs) False n  -- used as preprocessor -pgmF -F
+>                                             | otherwise     -> quitError preTooFewArgsError
 >                                       [Pre,Help] | length n >= 3 -> preprocess flags (reverse initdirs) True n  -- used as literate preprocessor -pgmL
+>                                                  | otherwise     -> quitError preTooFewArgsError
 >                                       [s]    -> lhs2TeX s flags (reverse initdirs) n
 >                                       _      -> quitError (incompatibleStylesError styles)
 >                                     when (output flags /= stdout) (hClose (output flags))
@@ -88,6 +90,9 @@
 >                                     exitFailure
 >    incompatibleStylesError ss =  "only one style allowed from: "
 >                                     ++ unwords (map (\s -> "--" ++ decode s) ss) ++ "\n"
+>    preTooFewArgsError         =  "\nlhs2TeX --pre was used with less than 3 args.\n"++
+>                                  "Use this mode as a (literate) preprocessor like `ghci -pgmL lhs2TeX -optL--pre File.lhs`,\n" ++
+>                                  "or test its output with `lhs2TeX --pre -h File.lhs File.lhs output.hs`.\n"
 
 > type Formatter                =  XIO Exc State ()
 


### PR DESCRIPTION
In https://github.com/kosmikus/lhs2tex/pull/95 I was very confused when `lhs2TeX --pre File.lhs` would crash somewhere in `display.select`. This patch emits a better error message in that case. I also added dist-newstyle to the .gitignore, and bumped the cabal-version to 2.0 autogen-modules are used.