### PR TITLE
FAQ entry addressing compile time performance

### DIFF
--- a/doc/Guide2.lhs
+++ b/doc/Guide2.lhs
@@ -1893,6 +1893,17 @@ formatting directives unless you make sure that they do never span
 an aligned column.
 %TODO: Write example.
 
+\begin{problem}
+My document takes ages to compile compared to a document of similar size in pure TeX.
+\end{problem}
+Make sure your macro expansions don't needlessly leave math mode only to re-enter it.
+For example, @\newcommand{\varid}[1]{\textbf{\textcolor{Blue}{#1}}}@, 
+@%format tau = \varid{$\tau$}@ is a code smell.
+Better factor out @\newcommand{\varcolor}[1]{{\color{Blue} #1}}@ and 
+define @%format tau = \varcolor{\tau}@.
+This issue is exacerbated when @acmart@ is included, due to
+an interaction between @microtype@ and @newtxmath@~\cite{microtype-newtxmath}.
+
 \begin{thebibliography}{99}
 
 \bibitem{polytable}
@@ -1925,6 +1936,10 @@ an aligned column.
 \bibitem{platform}
   The Haskell Platform.
   \url{http://hackage.haskell.org/platform/}
+
+\bibitem{platform}
+  TeX Exchange: Speed up macros involving `\text` when using `microtype` and `newtxmath`.
+  \url{https://tex.stackexchange.com/questions/702854/speed-up-macros-involving-text-when-using-microtype-and-newtxmath}
 
 \end{thebibliography}
 


### PR DESCRIPTION
For years I wondered why performance of the code generated by the `lhs2TeX` styling template I use (due to Richard Eisenberg) is so abyssmal when using `acmart`. It turns out this is due to an interaction between [`microtype` and `newtxmath`](https://tex.stackexchange.com/questions/702854/speed-up-macros-involving-text-when-using-microtype-and-newtxmath). I could speed up the pipeline greatly by getting rid of any entering of math mode from within `\text`, e.g., `\text{$x$}` is "bad". (Measurably so only with `acmart`.)

I added a FAQ entry.