### PR TITLE
Allow building with Cabal 3.14

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,22 +8,23 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.17.20231110
+# version: 0.19.20251211
 #
-# REGENDATA ("0.17.20231110",["github","lhs2tex.cabal"])
+# REGENDATA ("0.19.20251211",["github","lhs2tex.cabal"])
 #
 name: Haskell-CI
 on:
   - push
   - pull_request
+  - merge_group
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
@@ -66,44 +67,48 @@ jobs:
           - compiler: ghc-8.8.3
             compilerKind: ghc
             compilerVersion: 8.8.3
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+      - name: Install GHCup
+        run: |
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -114,30 +119,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -187,7 +174,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -212,10 +199,14 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_lhs2tex}" >> cabal.project
           echo "package lhs2tex" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package lhs2tex" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "package lhs2tex" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(lhs2tex|transformers)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(lhs2tex|transformers)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -223,7 +214,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -250,8 +241,8 @@ jobs:
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
-        uses: actions/cache/save@v3
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -79,11 +79,6 @@ jobs:
             compilerVersion: 8.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.2.2
-            compilerKind: ghc
-            compilerVersion: 8.2.2
-            setup-method: ghcup
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt-get install

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.3
+            compilerKind: ghc
+            compilerVersion: 9.10.3
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.8.1
             compilerKind: ghc
             compilerVersion: 9.8.1

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.3
             compilerKind: ghc
             compilerVersion: 9.10.3

--- a/Setup.hs
+++ b/Setup.hs
@@ -11,7 +11,6 @@ import Distribution.Simple.Setup (CopyDest(..),ConfigFlags(..),BuildFlags(..),
                                   defaultCopyFlags)
 import Distribution.Simple  (UserHooks(..), simpleUserHooks, defaultMainWithHooks)
 import Distribution.Simple.LocalBuildInfo
-                            (LocalBuildInfo(..),absoluteInstallDirs)
 import Distribution.PackageDescription (PackageDescription(..))
 import Distribution.Simple.InstallDirs
                             (InstallDirs(..))

--- a/Setup.hs
+++ b/Setup.hs
@@ -8,6 +8,9 @@
 import Distribution.Simple.Setup (CopyDest(..),ConfigFlags(..),BuildFlags(..),
                                   CopyFlags(..),RegisterFlags(..),InstallFlags(..),
                                   defaultRegisterFlags,fromFlagOrDefault,Flag(..),
+#if (MIN_VERSION_Cabal(3,14,0))
+                                  CommonSetupFlags(..),
+#endif
                                   defaultCopyFlags)
 import Distribution.Simple  (UserHooks(..), simpleUserHooks, defaultMainWithHooks)
 import Distribution.Simple.LocalBuildInfo
@@ -21,6 +24,9 @@ import Distribution.Simple.Program
 import Distribution.Simple.Program.Db (ProgramDb)
 import Distribution.Simple.Utils
 import Distribution.Verbosity
+#if (MIN_VERSION_Cabal(3,14,0))
+import Distribution.Utils.Path (getSymbolicPath)
+#endif
 import Data.Char (isSpace, showLitChar)
 import Data.List (isSuffixOf,isPrefixOf)
 import Data.Maybe (listToMaybe,isJust)
@@ -122,7 +128,7 @@ lhs2texPostConf a cf pd lbi =
                         hugs <- case hugsExists of
                                   Nothing -> return ""
                                   Just _  -> fmap fst (getProgram "hugs" (withPrograms lbi))
-                        let lhs2texDir = buildDir lbi `joinFileName` lhs2tex
+                        let lhs2texDir = buildDirString lbi `joinFileName` lhs2tex
                         let lhs2texBin = lhs2texDir `joinFileName` lhs2tex
                         readFile (f ++ ".in") >>= return .
                                                   -- these paths could contain backslashes, so we
@@ -140,10 +146,10 @@ lhs2texPostConf a cf pd lbi =
   where runKpseWhich v = runCommandProgramConf silent "kpsewhich" (withPrograms lbi) [v]
         runKpseWhichVar v = runKpseWhich $ "-expand-var='$" ++ v ++ "'"
 
-lhs2texPostBuild a bf@(BuildFlags { buildVerbosity = vf }) pd lbi =
-    do  let v = fromFlagOrDefault normal vf
+lhs2texPostBuild a bf@(BuildFlags { }) pd lbi =
+    do  let v = fromFlagOrDefault normal (buildVerbosity bf)
         ebi <- getPersistLhs2texBuildConfig
-        let lhs2texDir = buildDir lbi `joinFileName` lhs2tex
+        let lhs2texDir = buildDirString lbi `joinFileName` lhs2tex
         let lhs2texBin = lhs2texDir `joinFileName` lhs2tex
         let lhs2texDocDir = lhs2texDir `joinFileName` "doc"
         callLhs2tex v lbi ["--code", "lhs2TeX.sty.lit"] (lhs2texDir `joinFileName` "lhs2TeX.sty")
@@ -152,9 +158,9 @@ lhs2texPostBuild a bf@(BuildFlags { buildVerbosity = vf }) pd lbi =
         if rebuildDocumentation ebi then lhs2texBuildDocumentation a bf pd lbi
                                     else copyFileVerbose v ("doc" `joinFileName` "Guide2.pdf") (lhs2texDocDir `joinFileName` "Guide2.pdf")
 
-lhs2texBuildDocumentation a (BuildFlags { buildVerbosity = vf }) pd lbi =
-    do  let v = fromFlagOrDefault normal vf
-        let lhs2texDir = buildDir lbi `joinFileName` lhs2tex
+lhs2texBuildDocumentation a bf@(BuildFlags { }) pd lbi =
+    do  let v = fromFlagOrDefault normal (buildVerbosity bf)
+        let lhs2texDir = buildDirString lbi `joinFileName` lhs2tex
         let lhs2texBin = lhs2texDir `joinFileName` lhs2tex
         let lhs2texDocDir = lhs2texDir `joinFileName` "doc"
         snippets <- do  guide <- readFile $ "doc" `joinFileName` "Guide2.lhs"
@@ -194,13 +200,13 @@ lhs2texBuildDocumentation a (BuildFlags { buildVerbosity = vf }) pd lbi =
         loop
         setCurrentDirectory d
 
-lhs2texPostCopy a (CopyFlags { copyDest = cdf, copyVerbosity = vf }) pd lbi =
-    do  let v = fromFlagOrDefault normal vf
+lhs2texPostCopy a cf@(CopyFlags { copyDest = cdf }) pd lbi =
+    do  let v = fromFlagOrDefault normal (copyVerbosity cf)
         let cd = fromFlagOrDefault NoCopyDest cdf
         ebi <- getPersistLhs2texBuildConfig
         let dataPref = datadir (absoluteInstallDirs pd lbi cd)
         createDirectoryIfMissing True dataPref
-        let lhs2texDir = buildDir lbi `joinFileName` lhs2tex
+        let lhs2texDir = buildDirString lbi `joinFileName` lhs2tex
         -- lhs2TeX.{fmt,sty}
         mapM_ (\f -> installOrdinaryFile v (lhs2texDir `joinFileName` f) (dataPref `joinFileName` f))
               ["lhs2TeX.fmt","lhs2TeX.sty"]
@@ -234,11 +240,21 @@ lhs2texPostCopy a (CopyFlags { copyDest = cdf, copyVerbosity = vf }) pd lbi =
                                   stys
           Nothing    -> return ()
 
+#if (MIN_VERSION_Cabal(3,14,0))
+lhs2texPostInst a (InstallFlags { installPackageDB = db, installCommonFlags = f }) pd lbi =
+    do  lhs2texPostCopy a (defaultCopyFlags { copyDest = Flag NoCopyDest, copyCommonFlags = f }) pd lbi
+        lhs2texRegHook pd lbi Nothing (defaultRegisterFlags { regPackageDB = db, registerCommonFlags = f })
+#else
 lhs2texPostInst a (InstallFlags { installPackageDB = db, installVerbosity = v }) pd lbi =
     do  lhs2texPostCopy a (defaultCopyFlags { copyDest = Flag NoCopyDest, copyVerbosity = v }) pd lbi
         lhs2texRegHook pd lbi Nothing (defaultRegisterFlags { regPackageDB = db, regVerbosity = v })
+#endif
 
+#if (MIN_VERSION_Cabal(3,14,0))
+lhs2texRegHook pd lbi _ (RegisterFlags { registerCommonFlags = CommonSetupFlags { setupVerbosity = vf } }) =
+#else
 lhs2texRegHook pd lbi _ (RegisterFlags { regVerbosity = vf }) =
+#endif
     do  let v = fromFlagOrDefault normal vf
         ebi <- getPersistLhs2texBuildConfig
         when (isJust . installPolyTable $ ebi) $
@@ -278,7 +294,7 @@ stripQuotes ('\'':s@(_:_)) = init s
 stripQuotes x              = x
 
 callLhs2tex v lbi params outf =
-    do  let lhs2texDir = buildDir lbi `joinFileName` lhs2tex
+    do  let lhs2texDir = buildDirString lbi `joinFileName` lhs2tex
         let lhs2texBin = lhs2texDir `joinFileName` lhs2tex
         let args    =  [ "-P" ++ lhs2texDir ++ sep ]
                      ++ [ "-o" ++ outf ]
@@ -355,7 +371,7 @@ writePersistLhs2texBuildConfig lbi = do
 tryIO :: IO a -> IO (Either IOError a)
 tryIO = try
 
--- HACKS because the Cabal API isn't sufficient:
+-- HACKS because the Cabal API is only sufficient once we may assume version >= 3.14
 
 -- Distribution.Compat.FilePath is supposed to be hidden in future
 -- versions, so we need our own version of it:
@@ -372,6 +388,13 @@ joinFileName dir fname
                  | otherwise = ( == '/' )
  pathSeparator   | isWindows = '\\'
                  | otherwise = '/'
+
+
+#if (MIN_VERSION_Cabal(3,14,0))
+buildDirString = getSymbolicPath . buildDir
+#else
+buildDirString = buildDir
+#endif
 
 -- It would be nice if there'd be a predefined way to detect this
 isWindows = "mingw" `isPrefixOf` os || "win" `isPrefixOf` os

--- a/lhs2tex.cabal
+++ b/lhs2tex.cabal
@@ -24,7 +24,7 @@ description:
   be invoked in another mode to just extract the Haskell code.
 category:       Development, Language
 build-type:     Custom
-tested-with:    GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5, GHC == 9.6.3, GHC == 9.8.1
+tested-with:    GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5, GHC == 9.6.3, GHC == 9.8.1, GHC == 9.10.3
 extra-source-files:     AUTHORS
                         INSTALL
                         TODO
@@ -61,7 +61,7 @@ extra-doc-files:        CHANGELOG.md
 
 custom-setup
   setup-depends:        base >= 4.2 && < 5,
-                        Cabal >= 2.2 && < 3.11,
+                        Cabal >= 2.2 && < 3.13,
                         directory >= 1.3 && < 1.4,
                         process >= 1.6 && < 1.7,
                         regex-compat >= 0.95.2 && < 0.96
@@ -82,7 +82,7 @@ executable lhs2TeX
   build-depends:        base >= 4.2 && < 5,
                         regex-compat >= 0.95.2 && < 0.96,
                         mtl >= 2.2.1 && < 2.4,
-                        filepath >= 1.4 && < 1.5,
+                        filepath >= 1.4 && < 1.6,
                         directory >= 1.3 && < 1.4,
                         process >= 1.6 && < 1.7
   autogen-modules:      Version

--- a/lhs2tex.cabal
+++ b/lhs2tex.cabal
@@ -24,7 +24,7 @@ description:
   be invoked in another mode to just extract the Haskell code.
 category:       Development, Language
 build-type:     Custom
-tested-with:    GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5, GHC == 9.6.3, GHC == 9.8.1, GHC == 9.10.3, GHC == 9.12.2
+tested-with:    GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5, GHC == 9.6.3, GHC == 9.8.1, GHC == 9.10.3, GHC == 9.12.2
 extra-source-files:     AUTHORS
                         INSTALL
                         TODO

--- a/lhs2tex.cabal
+++ b/lhs2tex.cabal
@@ -24,7 +24,7 @@ description:
   be invoked in another mode to just extract the Haskell code.
 category:       Development, Language
 build-type:     Custom
-tested-with:    GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5, GHC == 9.6.3, GHC == 9.8.1, GHC == 9.10.3
+tested-with:    GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5, GHC == 9.6.3, GHC == 9.8.1, GHC == 9.10.3, GHC == 9.12.2
 extra-source-files:     AUTHORS
                         INSTALL
                         TODO
@@ -61,7 +61,7 @@ extra-doc-files:        CHANGELOG.md
 
 custom-setup
   setup-depends:        base >= 4.2 && < 5,
-                        Cabal >= 2.2 && < 3.13,
+                        Cabal >= 2.2 && < 3.15,
                         directory >= 1.3 && < 1.4,
                         process >= 1.6 && < 1.7,
                         regex-compat >= 0.95.2 && < 0.96


### PR DESCRIPTION
`lhs2TeX` is no longer buildable on nixos-stable. This PR should fix that, and add compatibility with Cabal 3.14 (which turned out to be quite hacky, but never change a running system). It cherry-picks #115 as well and regenerates the `haskell-ci` generated workflow.